### PR TITLE
[FEAT] 자체 로그인용 회원가입 기능

### DIFF
--- a/login/src/main/java/com/study/login/global/exception/CustomException.java
+++ b/login/src/main/java/com/study/login/global/exception/CustomException.java
@@ -1,0 +1,10 @@
+package com.study.login.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    ErrorCode errorCode;
+}

--- a/login/src/main/java/com/study/login/global/exception/CustomExceptionHandler.java
+++ b/login/src/main/java/com/study/login/global/exception/CustomExceptionHandler.java
@@ -1,0 +1,13 @@
+package com.study.login.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class CustomExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorDto> handleCustomException(CustomException e) {
+        return ErrorDto.toResponseEntity(e.getErrorCode());
+    }
+}

--- a/login/src/main/java/com/study/login/global/exception/ErrorCode.java
+++ b/login/src/main/java/com/study/login/global/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.study.login.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    ALEADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "USER-001","이미 가입된 이메일입니다."),
+    ALEADy_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "USER-002","이미 존재하는 닉네임입니다.")
+
+    ;
+
+    private final HttpStatus httpStatus; //HttpStatus
+    private final String code; // ex) ACCOUNT-001
+    private final String message; // 설명
+}

--- a/login/src/main/java/com/study/login/global/exception/ErrorDto.java
+++ b/login/src/main/java/com/study/login/global/exception/ErrorDto.java
@@ -1,0 +1,23 @@
+package com.study.login.global.exception;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.ResponseEntity;
+
+@Builder
+@Data
+public class ErrorDto {
+    private int status;
+    private String code;
+    private String msg;
+
+    public static ResponseEntity<ErrorDto> toResponseEntity(ErrorCode e) {
+        return ResponseEntity.status(e.getHttpStatus().value())
+                .body(ErrorDto.builder()
+                        .status(e.getHttpStatus().value())
+                        .code(e.getCode())
+                        .msg(e.getMessage())
+                        .build());
+    }
+}
+

--- a/login/src/main/java/com/study/login/user/controller/UserController.java
+++ b/login/src/main/java/com/study/login/user/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.study.login.user.controller;
+
+import com.study.login.global.exception.CustomException;
+import com.study.login.global.exception.ErrorCode;
+import com.study.login.user.dto.SignUpRequestDto;
+import com.study.login.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.View;
+
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+    private final View error;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@Valid @RequestBody SignUpRequestDto requestDto){
+        return ResponseEntity.status(HttpStatus.CREATED).body(userService.signup(requestDto));
+    }
+}

--- a/login/src/main/java/com/study/login/user/controller/UserController.java
+++ b/login/src/main/java/com/study/login/user/controller/UserController.java
@@ -1,15 +1,11 @@
 package com.study.login.user.controller;
 
-import com.study.login.global.exception.CustomException;
-import com.study.login.global.exception.ErrorCode;
 import com.study.login.user.dto.SignUpRequestDto;
 import com.study.login.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;

--- a/login/src/main/java/com/study/login/user/domain/Role.java
+++ b/login/src/main/java/com/study/login/user/domain/Role.java
@@ -1,0 +1,20 @@
+package com.study.login.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor // final 또는 @NotNull이 붙은 필드의 생성자를 자동으로 생성
+public enum Role {
+    /**
+     * OAuth2로그인에서 추가정보를 입력받기 위한 ROLE
+     *
+     * OAuth2 로그인: 첫 로그인시 GUEST로 설정, 추가 정보 입력시 USER로 업데이트
+     * 자체 로그인: 회원가입시 상관없이 USER로 설정되어 DB에 저장
+     */
+
+    GUEST("ROLE_GUEST"),
+    USER("ROLE_USER");
+
+    private final String key;
+}

--- a/login/src/main/java/com/study/login/user/domain/SocialType.java
+++ b/login/src/main/java/com/study/login/user/domain/SocialType.java
@@ -1,0 +1,5 @@
+package com.study.login.user.domain;
+
+public enum SocialType {
+    GOOGLE, KAKAO
+}

--- a/login/src/main/java/com/study/login/user/domain/User.java
+++ b/login/src/main/java/com/study/login/user/domain/User.java
@@ -1,0 +1,30 @@
+package com.study.login.user.domain;
+
+import jakarta.persistence.*;
+
+@Entity // 엔티티로 지정
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    // 기본 정보
+    private String email;
+    private String password;
+    private String nickname;
+
+    // 추가 정보
+    private int age;
+    private String city;
+
+    // GUEST, USER
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    // GOOGLE, KAKAO
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    private String socialId;
+}

--- a/login/src/main/java/com/study/login/user/domain/User.java
+++ b/login/src/main/java/com/study/login/user/domain/User.java
@@ -1,8 +1,13 @@
 package com.study.login.user.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity // 엔티티로 지정
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/login/src/main/java/com/study/login/user/dto/SignUpRequestDto.java
+++ b/login/src/main/java/com/study/login/user/dto/SignUpRequestDto.java
@@ -2,9 +2,6 @@ package com.study.login.user.dto;
 
 import com.study.login.user.domain.Role;
 import com.study.login.user.domain.User;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/login/src/main/java/com/study/login/user/dto/SignUpRequestDto.java
+++ b/login/src/main/java/com/study/login/user/dto/SignUpRequestDto.java
@@ -1,0 +1,31 @@
+package com.study.login.user.dto;
+
+import com.study.login.user.domain.Role;
+import com.study.login.user.domain.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignUpRequestDto {
+    private String email;
+    private String password;
+    private String nickname;
+    private int age;
+    private String city;
+
+    public User toEntity(){
+        return User.builder()
+                .email(this.email)
+                .password(this.password)
+                .nickname(this.nickname)
+                .age(this.age)
+                .city(this.city)
+                .role(Role.USER)
+                .build();
+    }
+}

--- a/login/src/main/java/com/study/login/user/repository/UserRepository.java
+++ b/login/src/main/java/com/study/login/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.study.login.user.repository;
+
+import com.study.login.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByNickname(String nickname);
+}

--- a/login/src/main/java/com/study/login/user/service/UserService.java
+++ b/login/src/main/java/com/study/login/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.study.login.user.service;
 
-import com.study.login.user.domain.Role;
 import com.study.login.user.domain.User;
 import com.study.login.user.dto.SignUpRequestDto;
 import com.study.login.global.exception.CustomException;

--- a/login/src/main/java/com/study/login/user/service/UserService.java
+++ b/login/src/main/java/com/study/login/user/service/UserService.java
@@ -1,0 +1,47 @@
+package com.study.login.user.service;
+
+import com.study.login.user.domain.Role;
+import com.study.login.user.domain.User;
+import com.study.login.user.dto.SignUpRequestDto;
+import com.study.login.global.exception.CustomException;
+import com.study.login.global.exception.ErrorCode;
+import com.study.login.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    // 자체 로그인 회원가입
+    public String signup(SignUpRequestDto requestDto){
+        // 이메일과 닉네임이 중복되는지 확인
+        if(isEmailExist(requestDto.getEmail())){
+            throw new CustomException(ErrorCode.ALEADY_EXIST_EMAIL);
+        }
+        if(isNicknameExist(requestDto.getNickname())){
+            throw new CustomException(ErrorCode.ALEADy_EXIST_NICKNAME);
+        }
+
+        // 이메일과 닉네임이 중복되지 않는다면 유저 저장
+        User user = userRepository.save(requestDto.toEntity());
+        return(user.getNickname() + "님의 회원가입이 완료되었습니다.");
+    }
+
+
+    /* Transactional 함수들 */
+    // 존재하는 이메일인지 확인하는 함수
+    @Transactional(readOnly = true)
+    public boolean isEmailExist(String email){
+        return userRepository.findByEmail(email).isPresent();
+    }
+
+    // 존재하는 닉네임인지 확인하는 함수
+    @Transactional(readOnly = true)
+    public boolean isNicknameExist(String nickname){
+        return userRepository.findByNickname(nickname).isPresent();
+    }
+}


### PR DESCRIPTION
## 🤷 구현 기능
- User 엔티티 생성
- 자체 로그인용 회원가입 기능 구현

## 🔨 구현 상태
- 회원가입 성공
![image](https://github.com/user-attachments/assets/1f2d3df2-2e65-4e3a-8c76-652f28e5af3e)

- 회원가입 실패(중복 이메일, 중복 닉네임)
![image](https://github.com/user-attachments/assets/e439d972-2743-471a-bca6-b59ab3e89d60)
![image](https://github.com/user-attachments/assets/558d4d3c-a7f0-4b21-ac8f-1a987a0d80fa)

## ✅ Resolve
- 이슈 태그: #1 #2 
